### PR TITLE
Refactor callback with closure via passthrough pointer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ notifications:
   email: false
 
 before_install:
-  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew install gcc; fi
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then
     sudo apt-get update -qq;
     sudo apt-get install -y gfortran libblas-dev liblapack-dev;

--- a/src/PROPACK.jl
+++ b/src/PROPACK.jl
@@ -4,33 +4,20 @@ export tsvd, tsvdvals, tsvd_irl, tsvdvals_irl
 
 include("wrappers.jl")
 
-global __mat__
-
-#Track number of matvecs
-global mvp1s = 0
-global mvp2s = 0
-
-# function __f__(transa, mm, nn, x, y, dparm, iparm)
-#     if Char(unsafe_load(transa)) == 'n'
-#         A_mul_B!(1.0, __mat__, pointer_to_array(x, unsafe_load(nn)), 0.0, pointer_to_array(y, unsafe_load(mm)))
-#     else
-#         Ac_mul_B!(1.0, __mat__, pointer_to_array(x, unsafe_load(mm)), 0.0, pointer_to_array(y, unsafe_load(nn)))
-#     end
-#     nothing
-# end
-function __f__(transa, mm, nn, x, y, dparm, iparm)
-    global mvp1s
-    global mvp2s
-    if Char(unsafe_load(transa)) == 'n'
-        tmp = __mat__*pointer_to_array(x, unsafe_load(nn))
-        unsafe_copy!(y, pointer(tmp), unsafe_load(mm))
-        mvp1s += 1
-    else
-        tmp = __mat__'pointer_to_array(x, unsafe_load(mm))
-        unsafe_copy!(y, pointer(tmp), unsafe_load(nn))
-        mvp2s += 1
-    end
-    nothing
+# callback using dparm as passthrough pointer to save the linear operator
+# thanks http://julialang.org/blog/2013/05/callback !
+function __f__{T}(transa_::Ptr{UInt8}, m_::Ptr{Int32}, n_::Ptr{Int32},
+                  x_::Ptr{T}, y_::Ptr{T}, dparm_::Ptr{T}, iparm::Ptr{Int32})
+  m = unsafe_load(m_)
+  n = unsafe_load(n_)
+  dparm = reinterpret(Ptr{Void}, dparm_)
+  transa = Char(unsafe_load(transa_))
+  A = unsafe_pointer_to_objref(dparm)::AbstractMatrix
+  (nargin, nargout) = transa == 'n' ? (n, m) : (m, n)
+  x = VERSION < v"0.5" ? pointer_to_array(x_, nargin) : unsafe_wrap(Array, x_, nargin)
+  y = transa == 'n' ? (A * x) : (A' * x)
+  unsafe_copy!(y_, pointer(y), nargout)
+  nothing
 end
 
 function tsvd{T}(A::AbstractMatrix{T};
@@ -38,26 +25,23 @@ function tsvd{T}(A::AbstractMatrix{T};
                  kmax::Integer = min(size(A)...)+10,
                  tolin::Real = sqrt(eps(real(one(T)))))
 
-    m, n = size(A)
-    global __mat__ = A
-    global mvp1s = 0
-    global mvp2s = 0
     __pf__ = cfunction(__f__, Void, (Ptr{UInt8}, Ptr{Int32}, Ptr{Int32}, Ptr{T}, Ptr{T}, Ptr{T}, Ptr{Int32}))
 
-    lansvd('Y', 'Y', m, n, __pf__, initvec, k, kmax, tolin)
+    m, n = size(A)
+    dparm = pointer_from_objref(A)
+    lansvd('Y', 'Y', m, n, __pf__, initvec, k, kmax, tolin, dparm)
 end
+
 function tsvdvals{T}(A::AbstractMatrix{T};
                      initvec::Vector{T} = zeros(T, size(A, 1)), k::Integer = 1,
                      kmax::Integer = min(size(A)...)+10,
                      tolin::Real = sqrt(eps(real(one(T)))))
 
-    m, n = size(A)
-    global __mat__ = A
-    global mvp1s = 0
-    global mvp2s = 0
     __pf__ = cfunction(__f__, Void, (Ptr{UInt8}, Ptr{Int32}, Ptr{Int32}, Ptr{T}, Ptr{T}, Ptr{T}, Ptr{Int32}))
 
-    _, s, _, bnd = lansvd('N', 'N', m, n, __pf__, initvec, k, kmax, tolin)
+    m, n = size(A)
+    dparm = pointer_from_objref(A)
+    _, s, _, bnd = lansvd('N', 'N', m, n, __pf__, initvec, k, kmax, tolin, dparm)
     return s, bnd
 end
 
@@ -67,26 +51,23 @@ function tsvd_irl{T}(A::AbstractMatrix{T};
                      p::Integer = 1, k::Integer = 1,
                      maxiter::Integer = min(size(A)...), tolin::Real = sqrt(eps(real(one(T)))))
 
-    m, n = size(A)
-    global __mat__ = A
-    global mvp1s = 0
-    global mvp2s = 0
     __pf__ = cfunction(__f__, Void, (Ptr{UInt8}, Ptr{Int32}, Ptr{Int32}, Ptr{T}, Ptr{T}, Ptr{T}, Ptr{Int32}))
 
-    lansvd_irl(smallest ? 'S' : 'L', 'Y', 'Y', m, n, kmax, p, k, maxiter, __pf__, initvec, tolin)
+    m, n = size(A)
+    dparm = pointer_from_objref(A)
+    lansvd_irl(smallest ? 'S' : 'L', 'Y', 'Y', m, n, kmax, p, k, maxiter, __pf__, initvec, tolin, dparm)
 end
+
 function tsvdvals_irl{T}(A::AbstractMatrix{T};
                          smallest::Bool = true, initvec::Vector{T} = zeros(T, size(A, 1)),
                          kmax::Integer = min(size(A)...)+10,
                          p::Integer = 1, k::Integer = 1,
                          maxiter::Integer = min(size(A)...), tolin::Real = sqrt(eps(real(one(T)))))
-    m, n = size(A)
-    global __mat__ = A
-    global mvp1s = 0
-    global mvp2s = 0
     __pf__ = cfunction(__f__, Void, (Ptr{UInt8}, Ptr{Int32}, Ptr{Int32}, Ptr{T}, Ptr{T}, Ptr{T}, Ptr{Int32}))
 
-    _, s, _, bnd = lansvd_irl(smallest ? 'S' : 'L', 'N', 'N', m, n, kmax, p, k, maxiter, __pf__, initvec, tolin)
+    m, n = size(A)
+    dparm = pointer_from_objref(A)
+    _, s, _, bnd = lansvd_irl(smallest ? 'S' : 'L', 'N', 'N', m, n, kmax, p, k, maxiter, __pf__, initvec, tolin, dparm)
     return s, bnd
 end
 

--- a/src/wrappers.jl
+++ b/src/wrappers.jl
@@ -34,7 +34,7 @@ for (fname, lname, elty) in ((:slansvd_, :libspropack, Float32),
         - ioption: [cgs, elr], where
             - cgs: 1 = classical Gram-Schmidt, 0 = modified Gram-Schmidt
             - elr: 1 = extended local orthogonality
-        - dparm: array for passing data to aprod
+        - dparm: array for passing data to aprod; WARNING: we use dparm as passthrough pointer!!!
         - iparm: array for passing integer data to aprod.
 
         Returns: (U, s, V, bnd).
@@ -43,7 +43,7 @@ for (fname, lname, elty) in ((:slansvd_, :libspropack, Float32),
             kmax::Integer, aprod, U::Array{$elty,2}, s::Vector{$elty},
             bnd::Vector{$elty}, V::Array{$elty,2}, tolin::$elty,
             work::Vector{$elty}, iwork::Vector{Int32}, doption::Vector{$elty},
-            ioption::Vector{Int32}, dparm::Vector{$elty}, iparm::Vector{Int32})
+            ioption::Vector{Int32}, dparm::Ptr{Void}, iparm::Vector{Int32})
 
             # extract values
             # in both Fortran and Julia, arrays are column major
@@ -94,7 +94,7 @@ for (fname, lname, elty) in ((:slansvd_, :libspropack, Float32),
             max(16ϵ s[1], tolin * s[i])
         """
         function lansvd(jobu::Char, jobv::Char, m::Integer, n::Integer, pff::Ptr{Void},
-            initvec::Vector{$elty}, k::Integer, kmax::Integer, tolin::$elty)
+            initvec::Vector{$elty}, k::Integer, kmax::Integer, tolin::$elty, dparm::Ptr{Void})
 
             # Extract
             U = Array($elty, m, kmax + 1)
@@ -118,7 +118,6 @@ for (fname, lname, elty) in ((:slansvd_, :libspropack, Float32),
             doption = $elty[sqrt(ϵ/k); ϵ^(3/4)/sqrt(k); 0.0]  # propack will estimate ‖A‖
             ioption = Int32[0; 1]
 
-            dparm = $elty[0]
             iparm = Int32[0]
 
             (U, s, V, bnd) = lansvd!(jobu, jobv, m, n, kmax, pff, U, s, bnd, V, tolin,
@@ -165,7 +164,7 @@ for (fname, lname, elty) in ((:slansvd_irl_, :libspropack, Float32),
         - ioption: [cgs, elr], where
             - cgs: 1 = classical Gram-Schmidt, 0 = modified Gram-Schmidt
             - elr: 1 = extended local orthogonality
-        - dparm: array for passing data to aprod
+        - dparm: array for passing data to aprod; WARNING: we use dparm as passthrough pointer!!!
         - iparm: array for passing integer data to aprod.
 
         Returns: (U, s, V, bnd).
@@ -175,7 +174,7 @@ for (fname, lname, elty) in ((:slansvd_irl_, :libspropack, Float32),
             maxiter::Integer, aprod, U::Array{$elty,2}, s::Vector{$elty},
             bnd::Vector{$elty}, V::Array{$elty,2}, tolin::$elty,
             work::Vector{$elty}, iwork::Vector{Int32}, doption::Vector{$elty},
-            ioption::Vector{Int32}, dparm::Vector{$elty}, iparm::Vector{Int32})
+            ioption::Vector{Int32}, dparm::Ptr{Void}, iparm::Vector{Int32})
 
             # extract values
             # in both Fortran and Julia, arrays are column major
@@ -232,7 +231,7 @@ for (fname, lname, elty) in ((:slansvd_irl_, :libspropack, Float32),
         """
         function lansvd_irl(which::Char, jobu::Char, jobv::Char, m::Integer,
             n::Integer, kmax::Integer, p::Integer, k::Integer, maxiter::Integer,
-            pff::Ptr{Void}, initvec::Vector{$elty}, tolin::$elty)
+            pff::Ptr{Void}, initvec::Vector{$elty}, tolin::$elty, dparm::Ptr{Void})
 
             # Extract
             U = Array($elty, m, kmax + 1)
@@ -256,7 +255,6 @@ for (fname, lname, elty) in ((:slansvd_irl_, :libspropack, Float32),
             doption = $elty[sqrt(ϵ); ϵ^(3/4); 0.0; ϵ^(1/6)]
             ioption = Int32[0; 1]
 
-            dparm = $elty[0]
             iparm = Int32[0]
 
             (U, s, V, bnd) = lansvd_irl!(which, jobu, jobv, m, n, kmax, p, maxiter,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,7 +14,7 @@ A = U * Σ * V'
 # compute a few leading singular values and vectors with lansvd
 k = 3
 tolin=sqrt(ϵ)
-U, s, V, bnd = tsvd(A, k=k, tolin=tolin)
+U, s, V, bnd, nprod, ntprod = tsvd(A, k=k, tolin=tolin)
 @assert size(U) == (m, k)
 @assert length(s) == k
 @assert size(V) == (n, k)
@@ -22,6 +22,7 @@ U, s, V, bnd = tsvd(A, k=k, tolin=tolin)
 println("computed singular values: ", s)
 println("exact singular values: ", σ[1:k])
 println("error bounds reported: ", bnd)
+println("number of matvecs and transposed matvecs: ", nprod, ", ", ntprod)
 for i = 1 : k
   @assert bnd[i] ≤ max(16ϵ * s[1], tolin * s[i])
   @assert abs(s[i] - σ[i]) ≤ tolin * σ[i]
@@ -29,15 +30,16 @@ end
 @assert norm(U * diagm(s) * V' - A) ≤ 1.1 * σ[k+1]
 
 # ensure tsvdvals returns the same singular value estimates
-s2, _ = tsvdvals(A, k=k, tolin=tolin)
+s2, _, nprod, ntprod = tsvdvals(A, k=k, tolin=tolin)
 println("computed singular values: ", s2)
+println("number of matvecs and transposed matvecs: ", nprod, ", ", ntprod)
 @assert norm(s - s2) ≤ sqrt(ϵ) * norm(s)
 
 # compute the two smallest singular values with tsvd_irl
 # we use A' to skip zero singular values
 k = 2
 σs = σ[n-k+1:n]
-U, s, V, bnd = tsvd_irl(A', k=k, tolin=tolin)
+U, s, V, bnd, nprod, ntprod = tsvd_irl(A', k=k, tolin=tolin)
 @assert size(U) == (n, k)
 @assert length(s) == k
 @assert size(V) == (m, k)
@@ -45,12 +47,14 @@ U, s, V, bnd = tsvd_irl(A', k=k, tolin=tolin)
 println("computed smallest singular values: ", s)
 println("exact smallest singular values: ", σs)
 println("error bounds reported: ", bnd)
+println("number of matvecs and transposed matvecs: ", nprod, ", ", ntprod)
 for i = 1 : k
   @assert bnd[i] ≤ max(16ϵ * s[1], tolin * s[i])
   @assert abs(s[i] - σs[i]) ≤ tolin * σs[i]
 end
 
 # ensure tsvdvals_irl returns the same singular value estimates
-s2, _ = tsvdvals_irl(A', k=k, tolin=tolin)
+s2, _, nprod, ntprod = tsvdvals_irl(A', k=k, tolin=tolin)
 println("computed smallest singular values: ", s2)
+println("number of matvecs and transposed matvecs: ", nprod, ", ", ntprod)
 @assert norm(s - s2) ≤ sqrt(ϵ) * norm(s)


### PR DESCRIPTION
This PR removes global variables. Currently, it also removes the matvec counters.