### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # PROPACK
 
-[![Build Status](https://travis-ci.org/JuliaSmoothOptimizers/PROPACK.jl.svg?branch=master)](https://travis-ci.org/JuliaSmoothOptimizers/PROPACK.jl)
-[![Build status](https://ci.appveyor.com/api/projects/status/s065u6mwkbyuldmw?svg=true)](https://ci.appveyor.com/project/dpo/propack-jl)
-[![Build Status](https://api.cirrus-ci.com/github/JuliaSmoothOptimizers/Krylov.jl.svg)](https://cirrus-ci.com/github/JuliaSmoothOptimizers/Krylov.jl)
-[![Coverage Status](https://coveralls.io/repos/github/JuliaSmoothOptimizers/PROPACK.jl/badge.svg?branch=master)](https://coveralls.io/github/JuliaSmoothOptimizers/PROPACK.jl?branch=master)
+| **Travis, AppVeyor and Cirrus build statuses** | **Coverage** |
+|:----------------------------------------------:|:------------:|
+| [![Build Status](https://travis-ci.org/JuliaSmoothOptimizers/PROPACK.jl.svg?branch=master)](https://travis-ci.org/JuliaSmoothOptimizers/PROPACK.jl) [![Build status](https://ci.appveyor.com/api/projects/status/s065u6mwkbyuldmw?svg=true)](https://ci.appveyor.com/project/dpo/propack-jl) [![Build Status](https://api.cirrus-ci.com/github/JuliaSmoothOptimizers/Krylov.jl.svg)](https://cirrus-ci.com/github/JuliaSmoothOptimizers/Krylov.jl) | [![Coverage Status](https://coveralls.io/repos/github/JuliaSmoothOptimizers/PROPACK.jl/badge.svg?branch=master)](https://coveralls.io/github/JuliaSmoothOptimizers/PROPACK.jl?branch=master) |
 
 A Julia interface to [PROPACK](http://sun.stanford.edu/~rmunk/PROPACK), a library for the computation of the truncated singular value decomposition of matrices or linear operators.
 PROPACK only requires operator-vector products to estimate singular values and singular vectors.
@@ -11,9 +10,10 @@ PROPACK only requires operator-vector products to estimate singular values and s
 ## How to Install
 
 ```julia
-julia> Pkg.clone("https://github.com/JuliaSmoothOptimizers/PROPACK.jl.git")
-julia> Pkg.build("PROPACK")
-julia> Pkg.test("PROPACK")
+julia> ]
+pkg> add PROPACK
+pkg> build PROPACK
+pkg> test PROPACK
 ```
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ PROPACK only requires operator-vector products to estimate singular values and s
 
 ## How to Install
 
+On Linux, you'll need to install `gfortran`, `libblas-dev` and `liblapack-dev` to be able to build PROPACK.
+
 ```julia
 julia> ]
 pkg> add PROPACK


### PR DESCRIPTION
I updated the `How to Install` section, the package is registered now.

I'm not sure if it's relevant, but with Ubuntu PROPACK wasn't working if some extra libraries weren't installed.
-> sudo apt-get install libblas-dev liblapack-dev
Maybe we should add a remark about it?