### PR TITLE
CI config udpates

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -6,10 +6,8 @@ task:
     matrix:
       - JULIA_VERSION: 1.3
       - JULIA_VERSION: nightly
+  allow_failures: $JULIA_VERSION == 'nightly'
   install_script:
-    - echo "FETCH_RETRY = 6" >> /usr/local/etc/pkg.conf
-    - pkg update
-    - pkg install -y gmake lang/gcc math/blas math/lapack
     - sh -c "$(fetch https://raw.githubusercontent.com/ararslan/CirrusCI.jl/master/bin/install.sh -o -)"
   build_script:
     - cirrusjl build

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,13 +26,6 @@ branches:
     - master
 
 before_install:
-  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then
-      sudo apt-get update -qq;
-      sudo apt-get install -y gfortran;
-      sudo ln -s /usr/lib/gcc/x86_64-linux-gnu/$(gfortran -dumpversion | cut -f1,2 -d.)/libgfortran.so /usr/local/lib;
-    else
-      brew update;
-    fi
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
 
 after_success:


### PR DESCRIPTION
- allow nightly failures
- no longer need to install gfortran/BLAS/LAPACK