### PR TITLE
Preallocated operator-vector products

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,7 +17,7 @@ for T ∈ (Float32, Float64, ComplexF32, ComplexF64)
   # compute a few leading singular values and vectors with lansvd
   k = 3
   tolin = sqrt(ϵ)
-  U, s, V, bnd, nprod, ntprod = tsvd(A, k=k, tolin=tolin)
+  U, s, V, bnd, nprod, nctprod = tsvd(A, k=k, tolin=tolin)
   @assert size(U) == (m, k)
   @assert length(s) == k
   @assert size(V) == (n, k)
@@ -25,7 +25,7 @@ for T ∈ (Float32, Float64, ComplexF32, ComplexF64)
   println("computed singular values: ", s)
   println("exact singular values: ", σ[1:k])
   println("error bounds reported: ", bnd)
-  println("number of matvecs and transposed matvecs: ", nprod, ", ", ntprod)
+  println("number of matvecs and conjugate transposed matvecs: ", nprod, ", ", nctprod)
   for i = 1 : k
     @assert bnd[i] ≤ max(16ϵ * s[1], tolin * s[i])
     @assert abs(s[i] - σ[i]) ≤ tolin * σ[i]
@@ -33,16 +33,16 @@ for T ∈ (Float32, Float64, ComplexF32, ComplexF64)
   @assert norm(U * diagm(0 => s) * V' - A) ≤ 1.2 * σ[k+1]
 
   # ensure tsvdvals returns the same singular value estimates
-  s2, _, nprod, ntprod = tsvdvals(A, k=k, tolin=tolin)
+  s2, _, nprod, nctprod = tsvdvals(A, k=k, tolin=tolin)
   println("computed singular values: ", s2)
-  println("number of matvecs and transposed matvecs: ", nprod, ", ", ntprod)
+  println("number of matvecs and conjugate transposed matvecs: ", nprod, ", ", nctprod)
   @assert norm(s - s2) ≤ sqrt(ϵ) * norm(s)
 
   # compute the two smallest singular values with tsvd_irl
   # we use A' to skip zero singular values
   k = 2
   σs = σ[n-k+1:n]
-  U, s, V, bnd, nprod, ntprod = tsvd_irl(A', k=k, tolin=tolin)
+  U, s, V, bnd, nprod, nctprod = tsvd_irl(A', k=k, tolin=tolin)
   @assert size(U) == (n, k)
   @assert length(s) == k
   @assert size(V) == (m, k)
@@ -50,16 +50,16 @@ for T ∈ (Float32, Float64, ComplexF32, ComplexF64)
   println("computed smallest singular values: ", s)
   println("exact smallest singular values: ", σs)
   println("error bounds reported: ", bnd)
-  println("number of matvecs and transposed matvecs: ", nprod, ", ", ntprod)
+  println("number of matvecs and conjugate transposed matvecs: ", nprod, ", ", nctprod)
   for i = 1 : k
     @assert bnd[i] ≤ max(16ϵ * s[1], tolin * s[i])
     @assert abs(s[i] - σs[i]) ≤ tolin * σs[i]
   end
 
   # ensure tsvdvals_irl returns the same singular value estimates
-  s2, _, nprod, ntprod = tsvdvals_irl(A', k=k, tolin=tolin)
+  s2, _, nprod, nctprod = tsvdvals_irl(A', k=k, tolin=tolin)
   println("computed smallest singular values: ", s2)
-  println("number of matvecs and transposed matvecs: ", nprod, ", ", ntprod)
+  println("number of matvecs and conjugate transposed matvecs: ", nprod, ", ", nctprod)
   @assert norm(s - s2) ≤ sqrt(ϵ) * norm(s)
   println()
 end


### PR DESCRIPTION
I also removed `PropackOperator`. A linear operator already has `nprod`, `ntprod` and `nctprod` attributes now.